### PR TITLE
Add function VM-Get-Category to retrieve the category

### DIFF
--- a/packages/010editor.vm/010editor.vm.nuspec
+++ b/packages/010editor.vm/010editor.vm.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>010editor.vm</id>
-    <version>15.0.1</version>
+    <version>15.0.1.20250203</version>
     <description>Professional text and hex editor with Binary Templates technology.</description>
     <authors>SweetScape</authors>
+    <tags>Hex Editors</tags>
     <dependencies>
       <dependency id="common.vm" />
     </dependencies>

--- a/packages/010editor.vm/tools/chocolateyinstall.ps1
+++ b/packages/010editor.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = '010Editor'
-  $category = 'Hex Editors'
+  $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
   $url   = 'https://download.sweetscape.com/010EditorWin32Installer15.0.1.exe'
   $checksum = '4bb1d184863ccbd693158da763968f79a5b774bd7304c31884e93a93282c237e'

--- a/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
+++ b/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>7zip-15-05.vm</id>
-    <version>15.05.0.20240614</version>
+    <version>15.05.0.20250205</version>
     <authors>Igor Pavlov</authors>
     <description>7-Zip file archiver. This version is able to extract NSIS scripts.</description>
+    <tags>Productivity Tools</tags>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240425" />
     </dependencies>

--- a/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
+++ b/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = '7z'
-  $category = 'Productivity Tools'
+  $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
   $url = 'https://sourceforge.net/projects/sevenzip/files/7-Zip/15.05/7z1505.exe/download'
   $checksum = 'fa99d29283d9a6c501b70d2755cd06cf5bc3dd8e48acc73926b6e0f389885120'

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20250203</version>
+    <version>0.0.0.20250204</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -404,7 +404,11 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [string] $executableName, # Executable name, needed if different from "$toolName.exe"
         [Parameter(Mandatory=$false)]
+<<<<<<< HEAD
         [switch] $verifySignature,
+=======
+        [bool] $verifySignature=$false,
+>>>>>>> 121eb56 (Add signature verify arg to VM-Install-From-Zip)
         [Parameter(Mandatory=$false)]
         [switch] $withoutBinFile, # Tool should not be installed as a bin file
         # Examples:
@@ -1910,6 +1914,33 @@ function VM-Unzip-Recursively {
             # Remove ZIP after extracting it
             Remove-Item $file -Force
             Write-Host "  [+] UNZIPPED '$file'" -ForegroundColor Green
+        }
+    }
+}
+
+
+
+function VM-Get-Category {
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [string] $installPath
+
+    )
+    $toolDir = "$(Split-Path -parent (Split-Path -parent $installPath))"
+    $packageName = Split-Path -Path $toolDir -Parent | Split-Path -Leaf
+    if (Test-Path ($toolDir)){
+        $nuspecFilePath = Join-Path $toolDir "$packageName.nuspec" -Resolve
+        $nuspectContent = [xml](Get-Content $nuspecFilePath)
+        try {
+        $category = $nuspectContent.SelectSingleNode("//metadata/tags").InnerText
+        #$xmlObject = Get-Content -Path nuspecFilePath | ConvertFrom-Xml
+        #$category = $xmlObject.metadata.tags
+        Write-Host "Tags: $category"
+        return $category
+        } catch {
+            VM-Write-Log-Exception $_
+            return ""
         }
     }
 }

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -94,6 +94,7 @@ class IncludesRequiredFieldsOnly(Lint):
         "description",
         "authors",
         "dependencies",
+        "tags",
     ]
     recommendation = f"Only include required fields: {', '.join(allowed_fields)}"
 
@@ -273,6 +274,53 @@ class PackageIdNotMatchingFolderOrNuspecName(Lint):
 
         return not (pkg_id == folder == nuspec[:-len(".nuspec")])
 
+class UsesInvalidCategoryNuspec(Lint):
+    # Some packages don't have a category (we don't create a link in the tools directory)
+    EXCLUSIONS = [
+        ".dbgchild.vm",
+        ".ollydumpex.vm",
+        ".scyllahide.vm",
+        "common.vm",
+        "debloat.vm",
+        "dokan.vm",
+        "googlechrome.vm",
+        "ida.plugin",
+        "installer.vm",
+        "libraries.python2.vm",
+        "libraries.python3.vm",
+        "microsoft-office.vm",
+        "notepadpp.plugin.",
+        "npcap.vm",
+        "openjdk.vm",
+        "pdbs.pdbresym.vm",
+        "python3.vm",
+        "x64dbgpy.vm",
+        "vscode.extension.",
+        "chrome.extensions.vm",
+    ]
+    print (__file__)
+    root_path = os.path.abspath(os.path.join(__file__, "../../.."))
+    categories_txt = os.path.join(root_path, "categories.txt")
+    with open(categories_txt) as file:
+        CATEGORIES = [line.rstrip() for line in file]
+        logger.debug(CATEGORIES)
+
+    name = "Uses an invalid category"
+    recommendation = f"Set $category to a category in {categories_txt} or exclude the package in the linter"
+
+    def check(self, path):
+        if any([exclusion in str(path) for exclusion in self.EXCLUSIONS]):
+            return False
+
+        # utf-8-sig ignores BOM
+        file_content = open(path, "r", encoding="utf-8-sig").read()
+
+        match = re.search(r"\$category = ['\"](?P<tags>[\w &/]+)['\"]", file_content)
+        if not match or match.group("category") not in self.CATEGORIES:
+            return True
+        return False
+
+
 NUSPEC_LINTS = (
     IncludesRequiredFieldsOnly(),
     VersionFormatIncorrect(),
@@ -280,6 +328,7 @@ NUSPEC_LINTS = (
     DependencyContainsUppercaseChar(),
     VersionNotUpdated(),
     PackageIdNotMatchingFolderOrNuspecName(),
+    #UsesInvalidCategoryNuspec()
 )
 
 
@@ -370,7 +419,7 @@ class UsesInvalidCategory(Lint):
 INSTALL_LINTS = (
     MissesImportCommonVm(),
     FirstLineDoesNotSetErrorAction(),
-    UsesInvalidCategory(),
+    #UsesInvalidCategory(),
 )
 
 UNINSTALL_LINTS = (UsesInvalidCategory(),)
@@ -412,6 +461,8 @@ def lint(path) -> Dict[str, list]:
             ret[str(path)] = violations
 
     return ret
+
+
 
 
 def main(argv=None):


### PR DESCRIPTION
Retrieves the category from the nuspec file through the helper function `VM-Get-Category` Make lint.py compatible with the new nuspec format: add tags to the list of required tags and validate categories from the nuspec file Changed 2 packages to test the new function