### PR TITLE
Add new function VM-Get-Category to retrieve the category from the nuspec

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20250204</version>
+    <version>0.0.0.20250206</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1915,3 +1915,22 @@ function VM-Unzip-Recursively {
         }
     }
 }
+# Obtains the chocolatey install script path from a package, for example: C:\ProgramData\chocolatey\lib\capa.vm\tools\chocolateyinstall.ps1
+# Reads the tag with name tags from the nuspec file,
+# Returns the category if the tags exist in the nuspec
+function VM-Get-Category {
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [string] $installPath
+
+    )
+    $chocoToolDir = $(Split-Path -parent (Split-Path -parent $installPath))
+    $packageName = ${Env:ChocolateyPackageName}
+    $nuspec = $packageName + ".nuspec"
+    VM-Assert-Path $chocoToolDir
+    $nuspecFilePath = Join-Path $chocoToolDir $nuspec -Resolve
+    $nuspecContent = [xml](Get-Content $nuspecFilePath)
+    $category = $nuspecContent.package.metadata.tags
+    return $category
+}

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -369,7 +369,9 @@ class UsesInvalidCategory(Lint):
 INSTALL_LINTS = (
     MissesImportCommonVm(),
     FirstLineDoesNotSetErrorAction(),
-    UsesInvalidCategory(),
+    #This line has been disabled temporarily because it would validate the category from the chocolatey install script
+    #It needs to be disabled until a new linter checks if a valid category exists in the nuspec package
+    #UsesInvalidCategory(),
 )
 
 UNINSTALL_LINTS = (UsesInvalidCategory(),)


### PR DESCRIPTION
Retrieves the category from the nuspec file through the helper function `VM-Get-Category`.
Remove the validation of categories in `lint.py` because there will coexist nuspec packages with additional tags sand some without. Make `lint.py` compatible with the new nuspec format: add tags to the list of required tags. The validation of categories is not yet implemented until the category is written in all the nuspec packages.
Changed 010 editor package and 7zip to test the new function